### PR TITLE
Update Fabric shim dependency for 2.x compatibility

### DIFF
--- a/oraclizeapi.go
+++ b/oraclizeapi.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	utf8 "unicode/utf8"
 	
-	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
 )
 
 /*


### PR DESCRIPTION
When trying to install oraclize-connector using the oraclizeapi.go dependency:

`github.com/hyperledger/fabric/core/chaincode/shim: module github.com/hyperledger/fabric@latest found (v2.1.1+incompatible), but does not contain package github.com/hyperledger/fabric/core/chaincode/shim`

Changing the dependency to look at `"github.com/hyperledger/fabric-chaincode-go/shim"` resolves this issue for Fabric 2.x.


